### PR TITLE
Pokemon Yellow: fix common encounter 3

### DIFF
--- a/GB/pokemon_yellow.yml
+++ b/GB/pokemon_yellow.yml
@@ -132,7 +132,7 @@ properties:
         - { type: "macro", address: 0xD887, macro: "encounter" }
         - { type: "macro", address: 0xD889, macro: "encounter" }
         - { type: "macro", address: 0xD88B, macro: "encounter" }
-        - { type: "macro", address: 0xD88C, macro: "encounter" }
+        - { type: "macro", address: 0xD88D, macro: "encounter" }
         - { type: "macro", address: 0xD88F, macro: "encounter" }
       uncommon:
         - { type: "macro", address: 0xD889, macro: "encounter" }


### PR DESCRIPTION
Pokemon Yellow:
Fix for a wrong address in encounters.common[3]
