### PR TITLE
Added X and Y map coordinates

### DIFF
--- a/GB/pokemon_crystal.yml
+++ b/GB/pokemon_crystal.yml
@@ -256,7 +256,8 @@ properties:
   overworld:
     mapGroup:  { type: "reference", address: 0xDCB5, size: 1, reference: "mapGroups" }
     mapNumber: { type: "int", address: 0xDCB6, size: 1 }
-    # map: { type: "reference", address: 0xDCB5, size: 2, reference: "maps" }
+    yCoord: { type: "int", address: 0xDCB7, size: 1 }
+    xCoord: { type: "int", address: 0xDCB8, size: 1 }
 
   roamers:
     - { type: "macro", address: 0xDFCF, macro: "roamer" }

--- a/GB/pokemon_crystal.yml
+++ b/GB/pokemon_crystal.yml
@@ -256,8 +256,8 @@ properties:
   overworld:
     mapGroup:  { type: "reference", address: 0xDCB5, size: 1, reference: "mapGroups" }
     mapNumber: { type: "int", address: 0xDCB6, size: 1 }
-    yCoord: { type: "int", address: 0xDCB7, size: 1 }
-    xCoord: { type: "int", address: 0xDCB8, size: 1 }
+    y: { type: "int", address: 0xDCB7, size: 1 }
+    x: { type: "int", address: 0xDCB8, size: 1 }
 
   roamers:
     - { type: "macro", address: 0xDFCF, macro: "roamer" }


### PR DESCRIPTION
These are often updated right after `mapGroup` and `mapNumber`, which is useful to detect when a change to this pair of properties is completed.

For example, if the player progresses from one `mapGroup` to another, but the `mapNumber` is the same, programs listening for changes on these two properties have no way to determine that the map change is completed. Listening also for coordinates tells that `mapNumber` is not going to change.

See for example:

https://github.com/pret/pokecrystal/blob/2fe0cbbb19df504723934f39473064033c64ef6f/engine/overworld/spawn_points.asm#L17

```asm
  ld [wMapGroup], a
  ld a, [hli]
  ld [wMapNumber], a
  ld a, [hli]
  ld [wXCoord], a
  ld a, [hli]
  ld [wYCoord], a
```

And also:

https://github.com/pret/pokecrystal/blob/2fe0cbbb19df504723934f39473064033c64ef6f/engine/overworld/warp_connection.asm#L32

```asm
  ld [wMapGroup], a
  ld a, [wWestConnectedMapNumber]
  ld [wMapNumber], a
  ld a, [wWestConnectionStripXOffset]
  ld [wXCoord], a
  ld a, [wWestConnectionStripYOffset]
  ld hl, wYCoord
  add [hl]
  ld [hl], a
```