### PR TITLE
[Yellow] Added multiple overworld logic flags 

### DIFF
--- a/GB/pokemon_crystal.yml
+++ b/GB/pokemon_crystal.yml
@@ -256,7 +256,8 @@ properties:
   overworld:
     mapGroup:  { type: "reference", address: 0xDCB5, size: 1, reference: "mapGroups" }
     mapNumber: { type: "int", address: 0xDCB6, size: 1 }
-    # map: { type: "reference", address: 0xDCB5, size: 2, reference: "maps" }
+    yCoord: { type: "int", address: 0xDCB7, size: 1 }
+    xCoord: { type: "int", address: 0xDCB8, size: 1 }
 
   roamers:
     - { type: "macro", address: 0xDFCF, macro: "roamer" }

--- a/GB/pokemon_crystal.yml
+++ b/GB/pokemon_crystal.yml
@@ -256,8 +256,8 @@ properties:
   overworld:
     mapGroup:  { type: "reference", address: 0xDCB5, size: 1, reference: "mapGroups" }
     mapNumber: { type: "int", address: 0xDCB6, size: 1 }
-    yCoord: { type: "int", address: 0xDCB7, size: 1 }
-    xCoord: { type: "int", address: 0xDCB8, size: 1 }
+    y: { type: "int", address: 0xDCB7, size: 1 }
+    x: { type: "int", address: 0xDCB8, size: 1 }
 
   roamers:
     - { type: "macro", address: 0xDFCF, macro: "roamer" }

--- a/GB/pokemon_yellow.yml
+++ b/GB/pokemon_yellow.yml
@@ -192,16 +192,57 @@ properties:
       lastMapLocation: { type: "reference", address: 0xD365, size: 1, reference: "maps" } #test
 
   events:
-    # un-sure what this does currently, flips to true when reset is pressed
-    # debugNewGame:
-    #   unknown1: { type: "bit", address: 0xD732, position: 0 }
-    #   unknown2: { type: "bit", address: 0xD732, position: 1 }
-    #   unknown3: { type: "bit", address: 0xD732, position: 2 }
-    #   unknown4: { type: "bit", address: 0xD732, position: 3 }
-    #   unknown5: { type: "bit", address: 0xD732, position: 4 }
-    #   unknown6: { type: "bit", address: 0xD732, position: 5 }
-    #   unknown7: { type: "bit", address: 0xD732, position: 6 }
-    #   unknown8: { type: "bit", address: 0xD732, position: 7 }
+    overworldFlags:
+      countPlayTime: { type: "bit", address: 0xD732, position: 0, description: "play time being counted" }
+      debugMode:
+        type: "bit"
+        address: 0xD732
+        position: 1
+        description: |
+          only set by the debug build
+            1. skips most of Prof. Oak's speech, and uses NINTEN as the player's name and SONY as the rival's name
+            2. does not have the player start in floor two of the player's house (instead sending them to [wLastMap])
+            3. allows wild battles to be avoided by holding down B
+            4. allows trainers to be avoided by holding down B
+            5. skips Safari Zone step counter by holding down B
+            6. skips the NPC who blocks Route 3 before beating Brock by holding down B
+            7. skips Cerulean City rival battle by holding down B
+            8. skips Pokémon Tower rival battle by holding down B
+      flyOrDungeon:
+        type: "bit"
+        address: 0xD732
+        position: 2
+        description: >
+          the target warp is a fly warp (bit 3 set or blacked out)
+          or a dungeon warp (bit 4 set)
+      flyWarp:
+        type: "bit"
+        address: 0xD732
+        position: 3
+        description: >
+          used warp pad, escape rope, dig, teleport, or fly,
+          so the target warp is a "fly warp"
+      dungeonWarp:
+        type: "bit"
+        address: 0xD732
+        position: 4
+        description: >
+          jumped into hole (Pokemon Mansion, Seafoam Islands, Victory Road)
+          or went down waterfall (Seafoam Islands),
+          so the target warp is a "dungeon warp"
+      forceBike:
+        type: "bit"
+        address: 0xD732
+        position: 5
+        description: "currently being forced to ride bike (cycling road)"
+      destinationIsBlackout:
+        type: "bit"
+        address: 0xD732
+        position: 6
+        description: >
+          map destination is [wLastBlackoutMap]
+          (usually the last used pokemon center, but could be the player's house)
+      unusedBit: { type: "bit", address: 0xD732, position: 7, description: "unused in game" }
     townMap:
       unknown1: { type: "bit", address: 0xD5F2, position: 0 }
       unknown2: { type: "bit", address: 0xD5F2, position: 1 }

--- a/GB/pokemon_yellow.yml
+++ b/GB/pokemon_yellow.yml
@@ -199,15 +199,15 @@ properties:
         address: 0xD732
         position: 1
         description: |
-          only set by the debug build
-            1. skips most of Prof. Oak's speech, and uses NINTEN as the player's name and SONY as the rival's name
-            2. does not have the player start in floor two of the player's house (instead sending them to [wLastMap])
-            3. allows wild battles to be avoided by holding down B
-            4. allows trainers to be avoided by holding down B
-            5. skips Safari Zone step counter by holding down B
-            6. skips the NPC who blocks Route 3 before beating Brock by holding down B
-            7. skips Cerulean City rival battle by holding down B
-            8. skips Pokémon Tower rival battle by holding down B
+          Only set by the debug build. If true:
+            * skips most of Prof. Oak's speech, and uses NINTEN as the player's name and SONY as the rival's name
+            * does not have the player start in floor two of the player's house (instead sending them to [wLastMap])
+            * allows wild battles to be avoided by holding down B
+            * allows trainers to be avoided by holding down B
+            * skips Safari Zone step counter by holding down B
+            * skips the NPC who blocks Route 3 before beating Brock by holding down B
+            * skips Cerulean City rival battle by holding down B
+            * skips Pokémon Tower rival battle by holding down B
       flyOrDungeon:
         type: "bit"
         address: 0xD732


### PR DESCRIPTION
Some flags that were not yet inegrated into the mapper now have readable names and descriptions.

Some of these flags help detect a wide variety of things, such as when the player presses "Continue" in the menu, without having to track inputs in HRAM.